### PR TITLE
Sync with bluez alsa 220708

### DIFF
--- a/libasound_module_pcm_cdsp.c
+++ b/libasound_module_pcm_cdsp.c
@@ -32,7 +32,7 @@
 #include "rt.h"
 #include "strrep.h"
 
-#define DEBUG 4
+#define DEBUG 2
 #define error(fmt, ...) \
   do { if(DEBUG > 0){fprintf(stderr,"CDSP Plugin ERROR: ");\
     fprintf(stderr,((fmt)), ##__VA_ARGS__);} } while (0)

--- a/rt.c
+++ b/rt.c
@@ -1,0 +1,89 @@
+/*
+ * BlueALSA - rt.h
+ * Copyright (c) 2016-2021 Arkadiusz Bokowy
+ *
+ * This file is a part of bluez-alsa.
+ *
+ * This project is licensed under the terms of the MIT license.
+ *
+ */
+
+#include "rt.h"
+
+#include <stdlib.h>
+
+/**
+ * Synchronize time with the sampling rate.
+ *
+ * Notes:
+ * 1. Time synchronization relies on the frame counter being linear.
+ * 2. In order to prevent frame counter overflow (for more information see
+ *   the asrsync structure definition), this counter should be initialized
+ *   (zeroed) upon every transfer stop.
+ *
+ * @param asrs Pointer to the time synchronization structure.
+ * @param frames Number of frames since the last call to this function.
+ * @return This function returns a positive value or zero respectively for
+ *   the case, when the synchronization was required or when blocking was
+ *   not necessary. If an error has occurred, -1 is returned and errno is
+ *   set to indicate the error. */
+int asrsync_sync(struct asrsync *asrs, unsigned int frames) {
+
+	const unsigned int rate = asrs->rate;
+	struct timespec ts_rate;
+	struct timespec ts;
+	int rv = 0;
+
+	asrs->frames += frames;
+	frames = asrs->frames;
+
+	ts_rate.tv_sec = frames / rate;
+	ts_rate.tv_nsec = 1000000000L / rate * (frames % rate);
+
+	gettimestamp(&ts);
+	/* calculate delay since the last sync */
+	timespecsub(&ts, &asrs->ts, &asrs->ts_busy);
+
+	/* maintain constant rate */
+	timespecsub(&ts, &asrs->ts0, &ts);
+	if (difftimespec(&ts, &ts_rate, &asrs->ts_idle) > 0) {
+		nanosleep(&asrs->ts_idle, NULL);
+		rv = 1;
+	}
+
+	gettimestamp(&asrs->ts);
+	return rv;
+}
+
+/**
+ * Calculate time difference for two time points.
+ *
+ * @param ts1 Address to the timespec structure providing t1 time point.
+ * @param ts2 Address to the timespec structure providing t2 time point.
+ * @param ts Address to the timespec structure where the absolute time
+ *   difference will be stored.
+ * @return This function returns an integer less than, equal to, or greater
+ *   than zero, if t2 time point is found to be, respectively, less than,
+ *   equal to, or greater than the t1 time point.*/
+int difftimespec(
+		const struct timespec *ts1,
+		const struct timespec *ts2,
+		struct timespec *ts) {
+
+	const struct timespec _ts1 = *ts1;
+	const struct timespec _ts2 = *ts2;
+
+	if (_ts1.tv_sec == _ts2.tv_sec) {
+		ts->tv_sec = 0;
+		ts->tv_nsec = labs(_ts2.tv_nsec - _ts1.tv_nsec);
+		return _ts2.tv_nsec - _ts1.tv_nsec;
+	}
+
+	if (_ts1.tv_sec < _ts2.tv_sec) {
+		timespecsub(&_ts2, &_ts1, ts);
+		return 1;
+	}
+
+	timespecsub(&_ts1, &_ts2, ts);
+	return -1;
+}

--- a/rt.h
+++ b/rt.h
@@ -57,7 +57,7 @@ struct asrsync {
 	/* time-stamp from the previous sync */
 	struct timespec ts;
 	/* transfered frames since ts0 */
-	uint32_t frames;
+	uint64_t frames;
 
 	/* time spent outside of the sync function */
 	struct timespec ts_busy;
@@ -66,6 +66,11 @@ struct asrsync {
 	 * contains an overdue time - synchronization was not possible due to
 	 * too much time spent outside of the sync function. */
 	struct timespec ts_idle;
+
+	/* indicates if running in sync mode or not
+	 * cdsp is started not in sync and after a period is switch in to sync mode.
+	 */
+	bool sync_mode;
 
 };
 
@@ -79,6 +84,7 @@ struct asrsync {
 		gettimestamp(&(asrs)->ts0); \
 		(asrs)->ts = (asrs)->ts0; \
 		(asrs)->frames = 0; \
+		(asrs)->sync_mode = false; \
 	} while (0)
 
 int asrsync_sync(struct asrsync *asrs, unsigned int frames);

--- a/rt.h
+++ b/rt.h
@@ -1,0 +1,109 @@
+/*
+ * BlueALSA - rt.h
+ * Copyright (c) 2016-2021 Arkadiusz Bokowy
+ *
+ * This file is a part of bluez-alsa.
+ *
+ * This project is licensed under the terms of the MIT license.
+ *
+ */
+
+#pragma once
+#ifndef BLUEALSA_SHARED_RT_H_
+#define BLUEALSA_SHARED_RT_H_
+
+#if HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <stdint.h>
+#include <sys/time.h>
+#include <time.h>
+
+#if HAVE_LIBBSD
+# include <bsd/sys/time.h>
+#else
+# define timespecadd(ts_a, ts_b, dest) do { \
+		(dest)->tv_sec = (ts_a)->tv_sec + (ts_b)->tv_sec; \
+		(dest)->tv_nsec = (ts_a)->tv_nsec + (ts_b)->tv_nsec; \
+		if ((dest)->tv_nsec >= 1000000000L) { \
+			(dest)->tv_sec++; \
+			(dest)->tv_nsec -= 1000000000L; \
+		} \
+	} while (0)
+# define timespecsub(ts_a, ts_b, dest) do { \
+		(dest)->tv_sec = (ts_a)->tv_sec - (ts_b)->tv_sec; \
+		(dest)->tv_nsec = (ts_a)->tv_nsec - (ts_b)->tv_nsec; \
+		if ((dest)->tv_nsec < 0) { \
+			(dest)->tv_sec--; \
+			(dest)->tv_nsec += 1000000000L; \
+		} \
+	} while (0)
+#endif
+
+/**
+ * Structure used for time synchronization.
+ *
+ * With the size of the frame counter being 32 bits, it is possible to track
+ * up to ~24 hours, with the sampling rate of 48 kHz. If it is insufficient,
+ * one can switch to 64 bits, which would suffice for 12 million years. */
+struct asrsync {
+
+	/* used sampling rate */
+	unsigned int rate;
+	/* reference time point */
+	struct timespec ts0;
+
+	/* time-stamp from the previous sync */
+	struct timespec ts;
+	/* transfered frames since ts0 */
+	uint32_t frames;
+
+	/* time spent outside of the sync function */
+	struct timespec ts_busy;
+	/* If the asrsync_sync() returns a positive value, then this variable
+	 * contains an amount of time used for synchronization. Otherwise, it
+	 * contains an overdue time - synchronization was not possible due to
+	 * too much time spent outside of the sync function. */
+	struct timespec ts_idle;
+
+};
+
+/**
+ * Start (initialize) time synchronization.
+ *
+ * @param asrs Pointer to the time synchronization structure.
+ * @param sr Synchronization sampling rate. */
+#define asrsync_init(asrs, sr) do { \
+		(asrs)->rate = sr; \
+		gettimestamp(&(asrs)->ts0); \
+		(asrs)->ts = (asrs)->ts0; \
+		(asrs)->frames = 0; \
+	} while (0)
+
+int asrsync_sync(struct asrsync *asrs, unsigned int frames);
+
+/**
+ * Get the number of microseconds spent outside of the sync function. */
+#define asrsync_get_busy_usec(asrs) \
+	((asrs)->ts_busy.tv_nsec / 1000)
+
+/**
+ * Get system monotonic time-stamp.
+ *
+ * @param ts Address to the timespec structure where the time-stamp will
+ *   be stored.
+ * @return On success this function returns 0. Otherwise, -1 is returned
+ *   and errno is set to indicate the error. */
+#ifdef CLOCK_MONOTONIC_RAW
+# define gettimestamp(ts) clock_gettime(CLOCK_MONOTONIC_RAW, ts)
+#else
+# define gettimestamp(ts) clock_gettime(CLOCK_MONOTONIC, ts)
+#endif
+
+int difftimespec(
+		const struct timespec *ts1,
+		const struct timespec *ts2,
+		struct timespec *ts);
+
+#endif


### PR DESCRIPTION
After kernel upgrade long term play introduces XRUNs.

Tried to sync the code with a recent version of bluez alsa (from 220708).
While it did fix the XRUNs, it also introduced artifacts on pause/play.

Reverted for to old delay variant for the first 100k samples and then switch to the new delay calculation.